### PR TITLE
Fallback to Piped when YouTube requires login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,13 @@
 	<dependency>
     	<groupId>com.github.teamnewpipe.NewPipeExtractor</groupId>
     	<artifactId>extractor</artifactId>
-    	<version>v0.24.6</version>   <!-- keep the leading 'v' -->
-	</dependency>
+        <version>v0.24.6</version>   <!-- keep the leading 'v' -->
+        </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20240303</version>
+    </dependency>
     <!-- JAVE2 core + native binaries (pick ONE native jar) -->
     <dependency>
       <groupId>ws.schild</groupId>
@@ -77,6 +82,10 @@
                 <relocation>
                   <pattern>ws.schild</pattern>
                   <shadedPattern>me.xai.shaded.jave</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.json</pattern>
+                  <shadedPattern>me.xai.shaded.json</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>


### PR DESCRIPTION
## Summary
- add Piped API fallback to download audio streams when NewPipe fails with bot-check errors
- parse Piped JSON with org.json and extract video IDs from URLs
- include org.json in shaded jar

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688feb0cb148832dbb70e05a15316e9e