### PR TITLE
Fallback to Piped when YouTube requires login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,13 @@
 	<dependency>
     	<groupId>com.github.teamnewpipe.NewPipeExtractor</groupId>
     	<artifactId>extractor</artifactId>
-    	<version>v0.24.6</version>   <!-- keep the leading 'v' -->
-	</dependency>
+        <version>v0.24.6</version>   <!-- keep the leading 'v' -->
+        </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20240303</version>
+    </dependency>
     <!-- JAVE2 core + native binaries (pick ONE native jar) -->
     <dependency>
       <groupId>ws.schild</groupId>
@@ -77,6 +82,10 @@
                 <relocation>
                   <pattern>ws.schild</pattern>
                   <shadedPattern>me.xai.shaded.jave</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.json</pattern>
+                  <shadedPattern>me.xai.shaded.json</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/src/main/java/me/xai/custommusicdiscs/CustomMusicDiscs.java
+++ b/src/main/java/me/xai/custommusicdiscs/CustomMusicDiscs.java
@@ -27,10 +27,14 @@ import org.schabi.newpipe.extractor.ServiceList;
 import org.schabi.newpipe.extractor.downloader.Downloader;
 import org.schabi.newpipe.extractor.downloader.Request;
 import org.schabi.newpipe.extractor.downloader.Response;
+import org.schabi.newpipe.extractor.exceptions.ContentNotAvailableException;
 import org.schabi.newpipe.extractor.localization.Localization;
 import org.schabi.newpipe.extractor.services.youtube.YoutubeService;
 import org.schabi.newpipe.extractor.stream.AudioStream;
 import org.schabi.newpipe.extractor.stream.StreamExtractor;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
 import ws.schild.jave.Encoder;
 import ws.schild.jave.MultimediaObject;
 import ws.schild.jave.encode.AudioAttributes;
@@ -94,10 +98,11 @@ public class CustomMusicDiscs extends JavaPlugin implements Listener, TabExecuto
             private static final int HTTP_PORT = 5523;
 
             /* --- NEW ---------------------------------------------------------------- */
-	    private final ExecutorService downloadPool = Executors.newFixedThreadPool(3);
-	    private static final Pattern YT_URL = Pattern.compile(
-	            "^(?:https?://)?(?:www\\.)?(?:youtube\\.com/watch\\?v=|youtu\\.be/)[\\w-]{11}.*$",
-	            Pattern.CASE_INSENSITIVE);
+            private final ExecutorService downloadPool = Executors.newFixedThreadPool(3);
+            private static final Pattern YT_URL = Pattern.compile(
+                    "^(?:https?://)?(?:www\\.)?(?:youtube\\.com/watch\\?v=|youtu\\.be/)[\\w-]{11}.*$",
+                    Pattern.CASE_INSENSITIVE);
+            private static final Pattern YT_ID_PATTERN = Pattern.compile("(?<=v=)[^&]+|(?<=be/)[^?&]+", Pattern.CASE_INSENSITIVE);
 
 	    /* ------------------------------------------------------------------ */
 	    /* LIFECYCLE                                                          */
@@ -408,32 +413,72 @@ public class CustomMusicDiscs extends JavaPlugin implements Listener, TabExecuto
 	    /* DOWNLOAD + CONVERT                                                  */
 	    /* ------------------------------------------------------------------ */
 
-	    private void downloadAndConvert(String youtubeUrl, Path targetOgg) throws Exception {
-                StreamingService yt = NewPipe.getService(ServiceList.YouTube.getServiceId());
-	        StreamExtractor extractor = yt.getStreamExtractor(youtubeUrl);
-	        extractor.fetchPage();
-	        List<AudioStream> audioStreams = extractor.getAudioStreams();
-	        if (audioStreams.isEmpty()) throw new IllegalStateException("No audio streams found");
-	        AudioStream best = audioStreams.stream().max(Comparator.comparingInt(AudioStream::getAverageBitrate)).orElseThrow();
+            private void downloadAndConvert(String youtubeUrl, Path targetOgg) throws Exception {
+                String audioUrl;
+                String suffix;
+                try {
+                    StreamingService yt = NewPipe.getService(ServiceList.YouTube.getServiceId());
+                    StreamExtractor extractor = yt.getStreamExtractor(youtubeUrl);
+                    extractor.fetchPage();
+                    List<AudioStream> audioStreams = extractor.getAudioStreams();
+                    if (audioStreams.isEmpty()) throw new IllegalStateException("No audio streams found");
+                    AudioStream best = audioStreams.stream()
+                            .max(Comparator.comparingInt(AudioStream::getAverageBitrate))
+                            .orElseThrow();
+                    audioUrl = best.getUrl();
+                    suffix   = best.getFormat().getSuffix();
+                } catch (ContentNotAvailableException ex) {
+                    getLogger().info("Falling back to Piped: " + ex.getMessage());
+                    String id = extractYoutubeId(youtubeUrl);
+                    URL api = new URL("https://piped.video/api/v1/streams/" + id);
+                    HttpURLConnection conn = (HttpURLConnection) api.openConnection();
+                    conn.setRequestProperty("User-Agent", "Mozilla/5.0");
+                    conn.setRequestProperty("Accept", "application/json");
+                    int status = conn.getResponseCode();
+                    InputStream resp = status == HttpURLConnection.HTTP_OK
+                            ? conn.getInputStream()
+                            : conn.getErrorStream();
+                    String json = new String(resp.readAllBytes(), StandardCharsets.UTF_8);
+                    if (status != HttpURLConnection.HTTP_OK)
+                        throw new IOException("Piped HTTP " + status + ": " + json);
+                    if (!json.trim().startsWith("{"))
+                        throw new IOException("Unexpected Piped response: " + json);
+                    JSONArray arr = new JSONObject(json).getJSONArray("audioStreams");
+                    if (arr.isEmpty()) throw new IllegalStateException("No audio streams found via Piped");
+                    JSONObject best = arr.getJSONObject(0);
+                    for (int i = 1; i < arr.length(); i++) {
+                        JSONObject s = arr.getJSONObject(i);
+                        if (s.optInt("bitrate", 0) > best.optInt("bitrate", 0)) best = s;
+                    }
+                    audioUrl = best.getString("url");
+                    suffix   = best.optString("format", best.optString("container", "m4a"));
+                }
 
-	        // download
-	        Path temp = Files.createTempFile("cmd_dl", "." + best.getFormat().getSuffix());
-	        try (InputStream in = new URL(best.getUrl()).openStream(); OutputStream out = Files.newOutputStream(temp, StandardOpenOption.WRITE)) {
-	            in.transferTo(out);
-	        }
+                // download
+                Path temp = Files.createTempFile("cmd_dl", "." + suffix);
+                try (InputStream in = new URL(audioUrl).openStream();
+                     OutputStream out = Files.newOutputStream(temp, StandardOpenOption.WRITE)) {
+                    in.transferTo(out);
+                }
 
-	        // convert via FFmpeg (JAVE2)
-	        AudioAttributes aa = new AudioAttributes();
-	        aa.setCodec("libvorbis");
-	        aa.setBitRate(160_000);
-	        aa.setChannels(2);
-	        aa.setSamplingRate(44_100);
+                // convert via FFmpeg (JAVE2)
+                AudioAttributes aa = new AudioAttributes();
+                aa.setCodec("libvorbis");
+                aa.setBitRate(160_000);
+                aa.setChannels(2);
+                aa.setSamplingRate(44_100);
                 EncodingAttributes ea = new EncodingAttributes();
                 ea.setOutputFormat("ogg");
                 ea.setAudioAttributes(aa);
-	        new Encoder().encode(new MultimediaObject(temp.toFile()), targetOgg.toFile(), ea);
-	        Files.deleteIfExists(temp);
-	    }
+                new Encoder().encode(new MultimediaObject(temp.toFile()), targetOgg.toFile(), ea);
+                Files.deleteIfExists(temp);
+            }
+
+            private String extractYoutubeId(String url) {
+                var m = YT_ID_PATTERN.matcher(url);
+                if (m.find()) return m.group();
+                throw new IllegalArgumentException("Invalid YouTube URL");
+            }
 
 	    /* ------------------------------------------------------------------ */
 	    /* MINI HTTP HANDLER                                                   */


### PR DESCRIPTION
## Summary
- add Piped API fallback to download audio streams when NewPipe fails with bot-check errors
- parse Piped JSON with org.json and extract video IDs from URLs
- include org.json in shaded jar

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688feb0cb148832dbb70e05a15316e9e