### PR TITLE
Fallback to Piped when YouTube requires login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,13 @@
 	<dependency>
     	<groupId>com.github.teamnewpipe.NewPipeExtractor</groupId>
     	<artifactId>extractor</artifactId>
-    	<version>v0.24.6</version>   <!-- keep the leading 'v' -->
-	</dependency>
+        <version>v0.24.6</version>   <!-- keep the leading 'v' -->
+        </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <version>20240303</version>
+    </dependency>
     <!-- JAVE2 core + native binaries (pick ONE native jar) -->
     <dependency>
       <groupId>ws.schild</groupId>
@@ -77,6 +82,10 @@
                 <relocation>
                   <pattern>ws.schild</pattern>
                   <shadedPattern>me.xai.shaded.jave</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.json</pattern>
+                  <shadedPattern>me.xai.shaded.json</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>


### PR DESCRIPTION
## Summary
- add Piped API host list and iterate through instances when NewPipe faces bot-check errors
- validate JSON responses and surface more informative errors from Piped fallback
- initialize audio URL and suffix before converting, preventing compilation errors when falling back to Piped
- restrict to API-only Piped instances, hit `/api/v1/streams` with timeouts and content-type checks

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688feb0cb148832dbb70e05a15316e9e